### PR TITLE
fix: Add Pillow to lock, use configparser

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+import configparser
+
+config = configparser.ConfigParser()
+config.read("settings.cfg")
+
+USE_HOTKEYS = True if config['GENERAL']['useHotKeys'] == 'yes' else False
+LEAGUE = config['GENERAL']['league']
+USE_GUI = True if config['GENERAL']['useGUI'] == 'yes' else False

--- a/parse.py
+++ b/parse.py
@@ -1,10 +1,9 @@
 import requests
-import json
 from tkinter import Tk, TclError
 import re
 import time
 from colorama import init, deinit, Fore, Back, Style
-import yaml
+from config import USE_GUI, USE_HOTKEYS, LEAGUE
 
 #Local imports
 from currency import (CURRENCY, OILS, CATALYSTS, FRAGMENTS_AND_SETS, INCUBATORS, SCARABS, RESONATORS,
@@ -14,10 +13,8 @@ DEBUG = False
 
 # If using hotkeys, we also import the hotkeys local module in the main loop.
 # If using GUI, import GUI
-with open("settings.yaml", "r") as settings_file:
-	settings = yaml.safe_load(settings_file)
 
-if settings['use_gui'] == True:
+if USE_GUI:
 	import testGui
 
 
@@ -821,7 +818,7 @@ def watch_clipboard(league):
 
 							# Print the pretty string, ignoring trailing comma 
 							print(f'[$] Price: {print_string[:-2]}\n\n')
-							if settings['use_gui'] == True:
+							if USE_GUI:
 
 								price = [re.findall(r"([0-9.]+)", tprice)[0] for tprice in prices.keys()]
 
@@ -855,7 +852,7 @@ def watch_clipboard(league):
 								price_curr = price['currency']
 								price = f"{price_val} x {price_curr}"
 
-								if settings['use_gui'] == True:
+								if USE_GUI:
 									testGui.assemble_price_gui(price, price_curr)
 
 							print("[$] Price:" + Fore.YELLOW + f" {price} "+ "\n\n")
@@ -876,11 +873,11 @@ if __name__ == "__main__":
 	root.withdraw()
 
 	for tleague in leagues['result']:
-		if settings['league'] == tleague['id']:
-			league = settings['league']
+		if LEAGUE == tleague['id']:
+			league = LEAGUE
 			print(f"All values will be from the " + Fore.MAGENTA + f"{league}" + Fore.WHITE + " league")
 
-	if settings['use_hotkeys'] == True:
+	if USE_HOTKEYS:
 		import hotkeys
 		hotkeys.watch_keyboard()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,7 +86,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.0.2"
+version = "8.1.0"
 
 [[package]]
 category = "dev"
@@ -99,6 +99,14 @@ version = "20.0"
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
+
+[[package]]
+category = "main"
+description = "Python Imaging Library (Fork)"
+name = "pillow"
+optional = false
+python-versions = ">=3.5"
+version = "7.0.0"
 
 [[package]]
 category = "dev"
@@ -1896,7 +1904,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "47dad6851d5e36104d4474e730341a0ecdc054ba5353032e43bc2b789ffec882"
+content-hash = "67915432d5e48612bc50e423fa3f254b011bdc536e417a3d48d80dd6ba2ba896"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1934,12 +1942,36 @@ keyboard = [
     {file = "keyboard-0.13.4.zip", hash = "sha256:b482b39df2644f62644ed16dce1db072654ba4b0a3eba1000231c129e084fac8"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.0.2.tar.gz", hash = "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d"},
-    {file = "more_itertools-8.0.2-py3-none-any.whl", hash = "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"},
+    {file = "more-itertools-8.1.0.tar.gz", hash = "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"},
+    {file = "more_itertools-8.1.0-py3-none-any.whl", hash = "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39"},
 ]
 packaging = [
     {file = "packaging-20.0-py2.py3-none-any.whl", hash = "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb"},
     {file = "packaging-20.0.tar.gz", hash = "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"},
+]
+pillow = [
+    {file = "Pillow-7.0.0-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:5f3546ceb08089cedb9e8ff7e3f6a7042bb5b37c2a95d392fb027c3e53a2da00"},
+    {file = "Pillow-7.0.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:9d2ba4ed13af381233e2d810ff3bab84ef9f18430a9b336ab69eaf3cd24299ff"},
+    {file = "Pillow-7.0.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:ff3797f2f16bf9d17d53257612da84dd0758db33935777149b3334c01ff68865"},
+    {file = "Pillow-7.0.0-cp35-cp35m-win32.whl", hash = "sha256:c18f70dc27cc5d236f10e7834236aff60aadc71346a5bc1f4f83a4b3abee6386"},
+    {file = "Pillow-7.0.0-cp35-cp35m-win_amd64.whl", hash = "sha256:875358310ed7abd5320f21dd97351d62de4929b0426cdb1eaa904b64ac36b435"},
+    {file = "Pillow-7.0.0-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:ab76e5580b0ed647a8d8d2d2daee170e8e9f8aad225ede314f684e297e3643c2"},
+    {file = "Pillow-7.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a62ec5e13e227399be73303ff301f2865bf68657d15ea50b038d25fc41097317"},
+    {file = "Pillow-7.0.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8ac6ce7ff3892e5deaab7abaec763538ffd011f74dc1801d93d3c5fc541feee2"},
+    {file = "Pillow-7.0.0-cp36-cp36m-win32.whl", hash = "sha256:91b710e3353aea6fc758cdb7136d9bbdcb26b53cefe43e2cba953ac3ee1d3313"},
+    {file = "Pillow-7.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:bf598d2e37cf8edb1a2f26ed3fb255191f5232badea4003c16301cb94ac5bdd0"},
+    {file = "Pillow-7.0.0-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:5bfef0b1cdde9f33881c913af14e43db69815c7e8df429ceda4c70a5e529210f"},
+    {file = "Pillow-7.0.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:dc058b7833184970d1248135b8b0ab702e6daa833be14035179f2acb78ff5636"},
+    {file = "Pillow-7.0.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c5ed816632204a2fc9486d784d8e0d0ae754347aba99c811458d69fcdfd2a2f9"},
+    {file = "Pillow-7.0.0-cp37-cp37m-win32.whl", hash = "sha256:54ebae163e8412aff0b9df1e88adab65788f5f5b58e625dc5c7f51eaf14a6837"},
+    {file = "Pillow-7.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:87269cc6ce1e3dee11f23fa515e4249ae678dbbe2704598a51cee76c52e19cda"},
+    {file = "Pillow-7.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0a628977ac2e01ca96aaae247ec2bd38e729631ddf2221b4b715446fd45505be"},
+    {file = "Pillow-7.0.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:62a889aeb0a79e50ecf5af272e9e3c164148f4bd9636cc6bcfa182a52c8b0533"},
+    {file = "Pillow-7.0.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bf4003aa538af3f4205c5fac56eacaa67a6dd81e454ffd9e9f055fff9f1bc614"},
+    {file = "Pillow-7.0.0-cp38-cp38-win32.whl", hash = "sha256:7406f5a9b2fd966e79e6abdaf700585a4522e98d6559ce37fc52e5c955fade0a"},
+    {file = "Pillow-7.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:5f7ae9126d16194f114435ebb79cc536b5682002a4fa57fa7bb2cbcde65f2f4d"},
+    {file = "Pillow-7.0.0-pp373-pypy36_pp73-win32.whl", hash = "sha256:8453f914f4e5a3d828281a6628cf517832abfa13ff50679a4848926dac7c0358"},
+    {file = "Pillow-7.0.0.tar.gz", hash = "sha256:4d9ed9a64095e031435af120d3c910148067087541131e82b3e8db302f4c8946"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.7"
 colorama = "^0.4.3"
 requests = "^2.22.0"
 keyboard = "^0.13.4"
-pyyaml = "^5.3"
+Pillow = "^7.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.2"

--- a/settings.cfg
+++ b/settings.cfg
@@ -1,0 +1,4 @@
+[GENERAL]
+useHotKeys = yes
+league = Metamorph
+useGUI = yes

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,8 +1,0 @@
-# Uses hotkeys, turn to False to not use hotkeys
-use_hotkeys: True
-
-# User's league
-league: Metamorph
-
-# Whether or not to use the GUI
-use_gui: True


### PR DESCRIPTION
Config parser is a little cleaner than yml configs. We can also use a settings.py file to load them and just import the vars like normal python.

Added Pillow to the pyproject.toml and the lockfile.