### PR TITLE
Move dependencies to requirements.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ For WINDOWS:
 
 For *NIX:
 * Ensure that your python version is 3.7 or above.
-* Install the following libraries:
-* `requests`, `pillow`, `keyboard`, `colorama`, and `typing`
+* Run `pip install -r requirements.txt` to install dependencies
 * Run parse.py
 
 For Everyone!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+pillow
+keyboard
+colorama
+typing


### PR DESCRIPTION
This is standardized format for Python dependencies

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>