### PR TITLE
Reuse and layout the GUI window

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -950,7 +950,7 @@ def price_item(text):
                             round(float(price[-1]), 2),
                         ]
 
-                        utils.gui.assemble_price_gui(price, currency)
+                        gui.show_price(price, currency)
 
                 else:
                     price = trade_info[0]["listing"]["price"]
@@ -960,7 +960,7 @@ def price_item(text):
                         price = f"{price_val} x {price_curr}"
 
                         if USE_GUI:
-                            utils.gui.assemble_price_gui(price, price_curr)
+                            gui.show_price(price, price_curr)
 
                     print(f"[$] Price: {Fore.YELLOW}{price} \n\n")
 
@@ -1070,7 +1070,8 @@ if __name__ == "__main__":
             hotkeys.watch_keyboard()
 
         if USE_GUI:
-            import utils.gui
+            from utils.gui import Gui
+            gui = Gui()
 
         # Begin our polling
         watch_clipboard()


### PR DESCRIPTION
- Instead of setting fixed size for the window, just let it size itself
  based on its contents
- Instead of creating entirely new window each time, just hide and show
  the already created window, and just update its contents (this fixes
  some issues for example on Linux, where the testGui window was never
  being hidden for me, even after .destroy())

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>