### PR TITLE
Hide GUI window on intitialization

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1150,9 +1150,7 @@ if __name__ == "__main__":
                 root.wm_attributes("-topmost", 1)
                 root.update()
                 root.withdraw()
-
                 gui = Gui()
-                gui.hide()
 
             watch_clipboard_no_hotkeys()
 
@@ -1163,9 +1161,7 @@ if __name__ == "__main__":
             root.wm_attributes("-topmost", 1)
             root.update()
             root.withdraw()
-
             gui = Gui()
-            gui.hide()
 
             if USE_HOTKEYS:
                 root.mainloop()

--- a/utils/gui.py
+++ b/utils/gui.py
@@ -59,6 +59,7 @@ class Gui:
         root = Toplevel()
         root.overrideredirect(True)
         root.option_add("*Font", "courier 12")
+        root.withdraw()
         return root
 
     def relayout_grid(self):
@@ -108,7 +109,6 @@ class Gui:
         abs_coord_x, abs_coord_y = self.mouse_pos()
         self.root.withdraw()
         self.root.geometry(f"-{abs_coord_x}-{abs_coord_y}")
-        # TODO: Either make another hide method, or move windowRefocus. It's called at initialization now...
         windowRefocus("path of exile")
 
     def show_price(self, price, price_vals, avg_times):


### PR DESCRIPTION
This removes the need to call .hide() after what also has unintended
side effects.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>