### PR TITLE
Refactor hotkey and GUI initialization

### DIFF
--- a/utils/gui.py
+++ b/utils/gui.py
@@ -53,6 +53,11 @@ def windowRefocus(name):
 
 class Gui:
     def __init__(self):
+        tk = Tk()
+        tk.wm_attributes("-topmost", 1)
+        tk.update()
+        tk.withdraw()
+
         self.root = self.prepare_window()
 
     def prepare_window(self):
@@ -61,6 +66,9 @@ class Gui:
         root.option_add("*Font", "courier 12")
         root.withdraw()
         return root
+
+    def wait(self):
+        self.root.mainloop()
 
     def relayout_grid(self):
         col_count, row_count = self.root.grid_size()


### PR DESCRIPTION
- Use same clipboard handler with or without hotkeys, when hotkeys are
  disabled simply do not register them
- Move root window initialization to GUI class
- Use mainloop on our Toplevel window instead of dummy root instance
- Fix issue with app immediatelly exiting with hotkeys enabled and gui
  disabled

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>