### PR TITLE
Row resize

### DIFF
--- a/utils/gui.py
+++ b/utils/gui.py
@@ -90,7 +90,7 @@ class Gui:
 
     def show(self):
         windowToFront(self.root)
-        self.relayout_grid()
+        #self.relayout_grid()
         self.root.update()
 
         mouse_x, mouse_y = self.mouse_pos()


### PR DESCRIPTION
The relayout_grid function was causing the GUI to have a default size that did not take into account current row count. I just removed the call to it for now and the issue has ceased.