### PR TITLE
Display not enough data dialog on <= config.MIN_RESULTS

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -11,7 +11,7 @@ from colorama import Fore, deinit, init
 # Local imports
 from enums.item_modifier_type import ItemModifierType
 from models.item_modifier import ItemModifier
-from utils.config import LEAGUE, PROJECT_URL, USE_GUI, USE_HOTKEYS
+from utils.config import LEAGUE, PROJECT_URL, USE_GUI, USE_HOTKEYS, MIN_RESULTS
 from utils.currency import (
     CATALYSTS,
     CURRENCY,
@@ -903,8 +903,8 @@ def watch_clipboard():
 
                     # If results found
                     if trade_info:
-                        # If more than 1 result, assemble price list.
-                        if len(trade_info) > 1:
+                        # If more than MIN_RESULTS results, assemble price list.
+                        if len(trade_info) >= MIN_RESULTS:
                             # print(trade_info[0]['item']['extended']) #TODO search this for bad mods
                             prev_account_name = ""
                             # Modify data to usable status.
@@ -960,21 +960,11 @@ def watch_clipboard():
                                 ]
 
                                 testGui.assemble_price_gui(price, currency)
-
                         else:
-                            price = trade_info[0]["listing"]["price"]
-                            if price != None:
-                                price_val = price["amount"]
-                                price_curr = price["currency"]
-                                price = f"{price_val} x {price_curr}"
-
-                                if USE_GUI:
-                                    testGui.assemble_price_gui(price, price_curr)
-
-                            print(f"[$] Price: {Fore.YELLOW}{price} \n\n")
-
+                            testGui.assemble_not_enough_data()
                     elif trade_info is not None:
                         print(f"[!] No results!")
+                        testGui.assemble_not_enough_data()
 
             time.sleep(0.3)
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -7,3 +7,4 @@ USE_HOTKEYS = True if config["GENERAL"]["useHotKeys"] == "yes" else False
 LEAGUE = config["GENERAL"]["league"]
 USE_GUI = True if config["GENERAL"]["useGUI"] == "yes" else False
 PROJECT_URL = config["GENERAL"]["projectURL"]
+MIN_RESULTS = 10

--- a/utils/testGui.py
+++ b/utils/testGui.py
@@ -14,6 +14,36 @@ if os.name == "nt":
 def windowEnumerationHandler(hwnd, top_windows):
     top_windows.append((hwnd, win32gui.GetWindowText(hwnd)))
 
+def assemble_not_enough_data():
+    root = Toplevel()
+    root.overrideredirect(True)
+
+    # This is necessary for displaying the GUI window above active window(s) on the Windows OS
+    if os.name == "nt":
+        # In order to prevent SetForegroundWindow from erroring, we must satisfy the requirements
+        # listed here:
+        # https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow
+        # We satisfy this by internally sending the alt character so that Windows believes we are
+        # an active window.
+        shell = win32com.client.Dispatch("WScript.Shell")
+        shell.SendKeys("%")
+        win32gui.SetForegroundWindow(root.winfo_id())
+
+    x = root.winfo_pointerx()
+    y = root.winfo_pointery()
+
+    abs_coord_x = root.winfo_pointerx() - root.winfo_rootx()
+    abs_coord_y = root.winfo_pointery() - root.winfo_rooty()
+    root.geometry(f"364x40+{abs_coord_x}+{abs_coord_y}")
+
+    text = "Not enough results found to confidently price this item."
+    annotation = "You should manually search for it."
+    Label(root, text=text).grid(column=0, row=0)
+    Label(root, text=annotation).grid(column=0, row=1)
+
+    root.update()
+    time.sleep(5)
+    root.destroy()
 
 def assemble_price_gui(price, currency):
     root = Toplevel()


### PR DESCRIPTION
Temporarily, when we don't have enough results to reliably price an item, we'll display a gui that tells the user this.

Tunables: `config.MIN_RESULTS`

In regards to https://github.com/Ethck/Path-of-Accounting/issues/108