### PR TITLE
Moved api calls out of parse.py

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -30,7 +30,7 @@ from utils.currency import (
     VIALS,
 )
 from utils.exceptions import InvalidAPIResponseException
-from utils.trade import find_latest_update, get_item_modifiers, get_leagues, get_ninja_bases, query_item, fetch
+from utils.trade import find_latest_update, get_item_modifiers, get_leagues, get_ninja_bases, query_item, fetch, exchange_currency
 from utils.web import open_trade_site, wiki_lookup
 
 DEBUG = False
@@ -695,8 +695,7 @@ def query_exchange(qcur):
     for haveCurrency in ["chaos", "exa", "mir"]:
         def_json = {"exchange": {"have": [haveCurrency], "want": [selection], "status": {"option": "online"},}}
 
-        query = requests.post(f"https://www.pathofexile.com/api/trade/exchange/{LEAGUE}", json=def_json)
-        res = query.json()
+        res = exchange_currency(def_json, LEAGUE)
         if DEBUG:
             print(def_json)
 

--- a/parse.py
+++ b/parse.py
@@ -30,7 +30,7 @@ from utils.currency import (
     VIALS,
 )
 from utils.exceptions import InvalidAPIResponseException
-from utils.trade import find_latest_update, get_item_modifiers, get_leagues, get_ninja_bases
+from utils.trade import find_latest_update, get_item_modifiers, get_leagues, get_ninja_bases, query_item, fetch
 from utils.web import open_trade_site, wiki_lookup
 
 DEBUG = False
@@ -216,53 +216,6 @@ def parse_item_info(text: str) -> Dict:
         print("COMPLETE INFO: ", info)
 
     return info
-
-
-def fetch(q_res: Dict, exchange: bool = False) -> List[Dict]:  # JSON
-    """
-    Fetch is the last step of the API. The item's attributes have already been decided, and this function checks to see if
-    there are any similar items like it listed.
-
-    returns JSON of all available similar items.
-    """
-
-    if DEBUG:
-        print(q_res)
-
-    results = []
-    # Limited to crawling by 10 results at a time due to API restrictions, so check first 50
-    # TODO: This doesn't work...
-    DEFAULT_CAP = 50
-    DEFAULT_INTERVAL = 10
-    cap = DEFAULT_CAP
-    interval = DEFAULT_INTERVAL
-
-    # If there's less than 10 results, change to the number there is.
-    if len(q_res) < DEFAULT_CAP:
-        cap = int((len(q_res) / 10) * 10)
-
-    # Find all the results
-    if "result" in q_res:
-        for i in range(0, cap, interval):
-            url = f'https://www.pathofexile.com/api/trade/fetch/{",".join(q_res["result"][i:i+10])}?query={q_res["id"]}'
-
-            if exchange:
-                url += "exchange=true"
-
-            res = requests.get(url)
-            if res.status_code != 200:
-                print(
-                    f"[!] Trade result retrieval failed: HTTP {res.status_code}! "
-                    f'Message: {res.json().get("error", "unknown error")}'
-                )
-                break
-
-            # Return the results from our fetch (this has who to whisper, prices, and more!)
-            results += res.json()["result"]
-    else:
-        raise InvalidAPIResponseException()
-
-    return results
 
 
 def build_json_official(
@@ -470,11 +423,11 @@ def search_item(j, league):
                 )
 
             # Make the actual request.
-            query = requests.post(f"https://www.pathofexile.com/api/trade/search/{league}", json=j)
+            res = query_item(j, league)
 
             # No results found. Trim the mod list until we find results.
-            if "result" in query.json():
-                if (len(query.json()["result"])) == 0:
+            if "result" in res:
+                if (len(res["result"])) == 0:
 
                     # Choose a non-priority mod
                     i = choose_bad_mod(j)
@@ -494,7 +447,6 @@ def search_item(j, league):
                     j["query"]["stats"][0]["filters"].remove(i)
                     num_stats_ignored += 1
                 else:  # Found a result!
-                    res = query.json()
                     results = fetch(res)
 
                     if DEBUG:
@@ -531,8 +483,7 @@ def search_item(j, league):
         raise InvalidAPIResponseException
 
     else:  # Any time we ignore stats.
-        query = requests.post(f"https://www.pathofexile.com/api/trade/search/{league}", json=j)
-        res = query.json()
+        res = query_item(j, league)
         results = fetch(res)
         return results
 
@@ -1133,8 +1084,7 @@ def hotkey_handler(hotkey):
                 )
             },
         )
-        query = requests.post(f"https://www.pathofexile.com/api/trade/search/{LEAGUE}", json=j)
-        res = query.json()
+        res = query_item(j, LEAGUE)
         open_trade_site(res["id"], LEAGUE)
 
     elif hotkey == "alt+w":

--- a/utils/trade.py
+++ b/utils/trade.py
@@ -11,6 +11,8 @@ from tqdm import tqdm
 from factories.item_modifier import build_from_json
 from models.item_modifier import ItemModifier
 from utils.config import RELEASE_URL, VERSION
+from utils.exceptions import InvalidAPIResponseException
+
 
 def query_item(query: dict, league: str) -> dict:
     """

--- a/utils/trade.py
+++ b/utils/trade.py
@@ -12,6 +12,63 @@ from factories.item_modifier import build_from_json
 from models.item_modifier import ItemModifier
 from utils.config import RELEASE_URL, VERSION
 
+def query_item(query: dict, league: str) -> dict:
+    """
+    :param query: A JSON query to send to the trade api
+    :param league: the leage (as a String) to search for items in
+    :return results: return a JSON object with the amount of items found and a key to get
+     item details
+    """
+    results = requests.post(f"https://www.pathofexile.com/api/trade/search/{league}", json=query)
+    return results.json()
+
+
+def fetch(q_res: dict, exchange: bool = False) -> List[dict]:  # JSON
+    """
+    Fetch is the last step of the API. The item's attributes have already been decided, and this function checks to see if
+    there are any similar items like it listed.
+
+    returns JSON of all available similar items.
+    """
+
+    # TODO: Bring back debug statement
+
+    results = []
+    # Limited to crawling by 10 results at a time due to API restrictions, so check first 50
+    # TODO: This doesn't work...
+    DEFAULT_CAP = 50
+    DEFAULT_INTERVAL = 10
+    cap = DEFAULT_CAP
+    interval = DEFAULT_INTERVAL
+
+    # If there's less than 10 results, change to the number there is.
+    if len(q_res) < DEFAULT_CAP:
+        cap = int((len(q_res) / 10) * 10)
+
+    # Find all the results
+    if "result" in q_res:
+        for i in range(0, cap, interval):
+            url = f'https://www.pathofexile.com/api/trade/fetch/{",".join(q_res["result"][i:i+10])}?query={q_res["id"]}'
+
+            if exchange:
+                url += "exchange=true"
+
+            res = requests.get(url)
+            if res.status_code != 200:
+                print(
+                    f"[!] Trade result retrieval failed: HTTP {res.status_code}! "
+                    f'Message: {res.json().get("error", "unknown error")}'
+                    )
+                break
+
+            # Return the results from our fetch (this has who to whisper, prices, and more!)
+            results += res.json()["result"]
+
+    else:
+        raise InvalidAPIResponseException()
+
+    return results
+
 
 def get_leagues() -> Tuple[str, ...]:
     """

--- a/utils/trade.py
+++ b/utils/trade.py
@@ -1,6 +1,4 @@
 import pathlib
-import subprocess
-import sys
 import zipfile
 from itertools import chain
 from typing import List, Tuple
@@ -17,7 +15,7 @@ from utils.exceptions import InvalidAPIResponseException
 def query_item(query: dict, league: str) -> dict:
     """
     :param query: A JSON query to send to the trade api
-    :param league: the leage (as a String) to search for items in
+    :param league: the league (as a String) to search for items in
     :return results: return a JSON object with the amount of items found and a key to get
      item details
     """

--- a/utils/trade.py
+++ b/utils/trade.py
@@ -12,10 +12,21 @@ from utils.config import RELEASE_URL, VERSION
 from utils.exceptions import InvalidAPIResponseException
 
 
+def exchange_currency(query: dict, league: str) -> dict:
+    """
+    :param query: A JSON query to send to the currency trade api
+    :param league: the league to search in
+    :return results: return a JSON object with the amount of items found and a key to get
+     item details
+    """
+    results = requests.post(f"https://www.pathofexile.com/api/trade/exchange/{league}", json=query)
+    return results.json()
+
+
 def query_item(query: dict, league: str) -> dict:
     """
     :param query: A JSON query to send to the trade api
-    :param league: the league (as a String) to search for items in
+    :param league: the league to search in
     :return results: return a JSON object with the amount of items found and a key to get
      item details
     """


### PR DESCRIPTION
The API calls now exist as functions in utils/trade.py. This enables them to be called by other part of the tool. They are currently light weight and leave the JSON creation to the calling function.

The next point is to move this JSON creation to a single module or class (like an Item class) to make using the API's easier.