### PR TITLE
Mocked Testing, Not Enough Data Display

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -941,7 +941,7 @@ def price_item(text):
             # If results found
             if trade_info:
                 # If more than 1 result, assemble price list.
-                if len(trade_info) >= MIN_RESULTS:
+                if len(trade_info) > 1:
                     # print(trade_info[0]['item']['extended']) #TODO search this for bad mods
                     prev_account_name = ""
                     # Modify data to usable status.
@@ -1015,10 +1015,14 @@ def price_item(text):
                             round(float(price[-1]), 2),
                         ]
 
-                        gui.show_price(price, list(prices), avg_times)
+                        if USE_GUI:
+                            gui.show_price(
+                                price, list(prices), avg_times,
+                                len(trade_info) < MIN_RESULTS
+                            )
                 else:
                     price = trade_info[0]["listing"]["price"]
-                    if price != None and bool(info["itype"]):
+                    if price != None:
                         price_val = price["amount"]
                         price_curr = price["currency"]
                         price = f"{price_val} x {price_curr}"
@@ -1030,16 +1034,18 @@ def price_item(text):
                         time = [[time.days, time.seconds]]
                         price_vals = [[str(price_val) + price_curr]]
 
+                        print("[!] Not enough data to confidently price this item.")
                         if USE_GUI:
-                            gui.show_price(price, price_vals, time)
+                            gui.show_price(price, price_vals, time, True)
                     else:
-                        print(f"[!] Not enough data to confidently price this item.")
+                        print(f"[$] Price: {Fore.YELLOW}None \n\n")
+                        print("[!] Not enough data to confidently price this item.")
                         if USE_GUI:
                             gui.show_not_enough_data()
 
-
             elif trade_info is not None:
-                print(f"[!] Not enough data to confidently price this item.")
+                print("[!] No reesults!")
+                print("[!] Not enough data to confidently price this item.")
                 if USE_GUI:
                     gui.show_not_enough_data()
 

--- a/parse.py
+++ b/parse.py
@@ -15,7 +15,7 @@ from colorama import Fore, deinit, init
 # Local imports
 from enums.item_modifier_type import ItemModifierType
 from models.item_modifier import ItemModifier
-from utils.config import LEAGUE, PROJECT_URL, USE_GUI, USE_HOTKEYS
+from utils.config import LEAGUE, PROJECT_URL, USE_GUI, USE_HOTKEYS, MIN_RESULTS
 from utils.currency import (
     CATALYSTS,
     CURRENCY,

--- a/parse.py
+++ b/parse.py
@@ -942,7 +942,7 @@ def price_item(text):
             # If results found
             if trade_info:
                 # If more than 1 result, assemble price list.
-                if len(trade_info) > 1:
+                if len(trade_info) >= MIN_RESULTS:
                     # print(trade_info[0]['item']['extended']) #TODO search this for bad mods
                     prev_account_name = ""
                     # Modify data to usable status.

--- a/parse.py
+++ b/parse.py
@@ -11,7 +11,7 @@ from colorama import Fore, deinit, init
 # Local imports
 from enums.item_modifier_type import ItemModifierType
 from models.item_modifier import ItemModifier
-from utils.config import LEAGUE, PROJECT_URL, USE_GUI, USE_HOTKEYS
+from utils.config import LEAGUE, PROJECT_URL, USE_GUI, USE_HOTKEYS, MIN_RESULTS
 from utils.currency import (
     CATALYSTS,
     CURRENCY,
@@ -903,8 +903,8 @@ def watch_clipboard():
 
                     # If results found
                     if trade_info:
-                        # If more than 1 result, assemble price list.
-                        if len(trade_info) > 1:
+                        # If more than MIN_RESULTS results, assemble price list.
+                        if len(trade_info) >= MIN_RESULTS:
                             # print(trade_info[0]['item']['extended']) #TODO search this for bad mods
                             prev_account_name = ""
                             # Modify data to usable status.
@@ -960,21 +960,11 @@ def watch_clipboard():
                                 ]
 
                                 testGui.assemble_price_gui(price, currency)
-
                         else:
-                            price = trade_info[0]["listing"]["price"]
-                            if price != None:
-                                price_val = price["amount"]
-                                price_curr = price["currency"]
-                                price = f"{price_val} x {price_curr}"
-
-                                if USE_GUI:
-                                    testGui.assemble_price_gui(price, price_curr)
-
-                            print(f"[$] Price: {Fore.YELLOW}{price} \n\n")
-
+                            testGui.assemble_not_enough_data()
                     elif trade_info is not None:
                         print(f"[!] No results!")
+                        testGui.assemble_not_enough_data()
 
             time.sleep(0.3)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ dataclasses==0.6
 idna==2.8
 keyboard==0.13.4
 Pillow==7.0.0
-pkg-resources==0.0.0
 pyperclip==1.7.0
 pypiwin32==223; platform_system == "Windows"
 pywin32==227; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,18 @@ attrs==19.3.0
 certifi==2019.11.28
 chardet==3.0.4
 colorama==0.4.3
+dataclasses==0.6
 idna==2.8
 keyboard==0.13.4
 Pillow==7.0.0
+pkg-resources==0.0.0
 pyperclip==1.7.0
 pypiwin32==223; platform_system == "Windows"
 pywin32==227; platform_system == "Windows"
 requests==2.22.0
+requests-mock==1.7.0
 screeninfo==0.6.1
+six==1.14.0
 tqdm==4.41.1
 typing==3.7.4.1
 urllib3==1.25.7

--- a/testing.py
+++ b/testing.py
@@ -1,21 +1,163 @@
 import io
 import sys
 import unittest
+import requests_mock
+import json
+from collections import OrderedDict
+from datetime import datetime, timezone
+from colorama import Fore, deinit, init
 
 import parse
+from utils import config
+from tests.mocks import *
 from tests.sampleItems import items
 
+LOOKUP_URL = "https://www.pathofexile.com/api/trade/search/Metamorph"
 
 class TestItemLookup(unittest.TestCase):
     def test_lookups(self):
+        # Mockups of response data from pathofexile.com/trade
+        expected = [
+            # (mocked up json response, expected condition)
+            (mockResponse(11), lambda v: "[$]" in v),
+            (mockResponse(12), lambda v: "[$]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(1), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(66), lambda v: "[$]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(0), lambda v: "[!]" in v),
+            (mockResponse(10), lambda v: "[$]" in v),
+        ]
+
+        # Mocked up prices to return when searching. We only take the first
+        # 10 results from any search. We don't have to worry about sorting by
+        # price here, as we know that PoE/trade sorts by default.
+        prices = [
+            [ # List 1
+                (45, "alch"),
+            ] * 10,
+            [ # List 2
+                # 5 x 1 chaos
+                *(((1, "chaos"),) * 5),
+                # 1 x 3 chaos
+                (3, "chaos"),
+                # 4 x 2 alch
+                *(((2, "alch"),) * 4)
+            ],
+            [], # List 3
+            [], # List 4
+            [ # List 5
+                (666, "exa")
+            ],
+            [], # List 6
+            [], # List 7
+            [], # List 8
+            [], # List 9
+            [], # List 10
+            [ # List 11
+                (2.5, "mir")
+            ] * 10,
+            [], # List 12
+            [], # List 13
+            [], # List 14
+            [], # List 15
+            [ # List 16
+                (1, "fuse")
+            ] * 10,
+        ]
+
         for i in range(len(items)):
             with self.subTest(i=i):
+                sortedPrices = sorted(prices[i])
+                priceCount = OrderedDict()
+                for price in sortedPrices:
+                    if price in priceCount:
+                        priceCount[price] += 1
+                    else:
+                        priceCount[price] = 1
+
+                # Middleman our stdout, so we can check programmatically
                 out = io.StringIO()
                 sys.stdout = out
-                parse.price_item(items[i])
-                sys.stdout = sys.__stdout__
-                self.assertTrue("[$]" in out.getvalue())
 
+                # Mockup response
+                with requests_mock.Mocker() as mock:
+                    mock.post(
+                        LOOKUP_URL,
+                        json=expected[i][0]
+                    )
+
+                    response = {
+                        "result": [
+                            {
+                                "id": "result%d" % x,
+                                "listing": {
+                                    # Mocked account name of the lister
+                                    "account": { "name": "account%d" % x },
+
+                                    # Price of this item result; we should mock
+                                    # and test against this amount.
+                                    "price": {
+                                        "type": "~",
+                                        "amount": sortedPrices[x][0],
+                                        "currency": sortedPrices[x][1]
+                                    },
+
+                                    # Indexed now.
+                                    "indexed": datetime.strftime(
+                                        datetime.now(timezone.utc),
+                                        "%Y-%m-%dT%H:%M:%SZ"
+                                    ),
+                                }
+                            } for x in range(min(expected[i][0]["total"], 10))
+                        ]
+                    }
+                    # If we have at least MIN_RESULTS items, we should mock
+                    # the GET request for fetching the first 10 items.
+                    # See search_item's pathing in parse.py
+                    if len(expected[i][0]["result"]) >= config.MIN_RESULTS:
+                        fetch_url = makeFetchURL(expected[i][0])
+                        mock.get(fetch_url, json=response)
+
+                    # Callout to API and price the item
+                    parse.price_item(items[i])
+
+                # Get the expected condition
+                currentExpected = expected[i][1]
+
+                # Restore stdout and assert that the expected condition is true
+                sys.stdout = sys.__stdout__
+
+                # Expect that our truthy condition is true
+                self.assertTrue(currentExpected(out.getvalue()))
+
+                if len(expected[i][0]["result"]) >= config.MIN_RESULTS:
+                    # Expect that the currency is output properly, including
+                    # the color(s) expected.
+                    priceList = []
+                    for k, v in priceCount.items():
+                        # Normalize any non-integer decimal number. That is,
+                        # if k[0] == int(k[0]), output it as a pure integer.
+                        # Otherwise, use the string formatter, so 2.750
+                        # becomes 2.75 but retains it's floating pointness.
+                        fmt = "%i" if int(k[0]) == k[0] else "%s"
+                        priceList.append(
+                            ("%d x %s" + fmt + " %s") % (
+                                v, Fore.YELLOW, k[0], k[1]
+                            )
+                        )
+                    expectedStr = ("%s, " % Fore.WHITE).join(priceList)
+                    self.assertTrue(expectedStr in out.getvalue())
 
 if __name__ == "__main__":
-    unittest.main()
+    init(autoreset=True) # Colorama
+    unittest.main(failfast=True)
+    deinit()

--- a/testing_legacy.py
+++ b/testing_legacy.py
@@ -1,0 +1,21 @@
+import io
+import sys
+import unittest
+
+import parse
+from tests.sampleItems import items
+
+
+class TestItemLookup(unittest.TestCase):
+    def test_lookups(self):
+        for i in range(len(items)):
+            with self.subTest(i=i):
+                out = io.StringIO()
+                sys.stdout = out
+                parse.price_item(items[i])
+                sys.stdout = sys.__stdout__
+                self.assertTrue("[$]" in out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing_legacy.py
+++ b/testing_legacy.py
@@ -14,8 +14,8 @@ class TestItemLookup(unittest.TestCase):
                 sys.stdout = out
                 parse.price_item(items[i])
                 sys.stdout = sys.__stdout__
-                self.assertTrue("[$]" in out.getvalue())
-
+                alternate = "[!] Not enough data to confidently price this item."
+                self.assertTrue("[$]" in out.getvalue() or alternate in out.getvalue())
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,60 @@
+import sys
+import os
+
+# Append the root directory to sys.path so we can import like normal.
+BASE_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(os.path.join(BASE_DIR, ".."))
+
+import parse
+
+# A helper used to generate a mock dictionary response
+# from a PoE/trade POST request.
+#
+# n: Number of trade results to generate.
+# Returns mock dictionary response.
+def mockResponse(n):
+    return {
+        # result0, result1, result2, ...
+        "result": [
+            "result%d" % i for i in range(n)
+        ],
+        # Don't change this during mock for simplification
+        "id": "mockID",
+        "total": n
+    }
+
+# A helper that takes a JSON result from PoE/trade search and generates
+# a URL used to fetch the items after the POST request.
+#
+# result: A MockResponse dict-converted value
+# Returns a formatted fetch URL.
+def makeFetchURL(result):
+    return f'https://www.pathofexile.com/api/trade/fetch/{",".join(result["result"][0:10])}?query={result["id"]}'
+
+# A simple helper function that generates the (info, json) of
+# an item before using them to search the item on PoE/trade.
+#
+# Returns a tuple (item info, json data)
+def makeItemInfo(item):
+    info = parse.parse_item_info(items[i])
+    data = parse.build_json_official(
+        **{
+            k: v
+            for k, v in info.items()
+            if k
+            in (
+                "name",
+                "itype",
+                "ilvl",
+                "links",
+                "corrupted",
+                "influenced",
+                "stats",
+                "rarity",
+                "gem_level",
+                "quality",
+                "maps",
+            )
+        },
+    )
+    return (info, data)

--- a/tests/sampleItems.py
+++ b/tests/sampleItems.py
@@ -1,4 +1,5 @@
 items = [
+    # 1
     f"""Rarity: Rare
 Corruption Spiker
 Boot Blade
@@ -31,6 +32,7 @@ Adds 25 to 47 Cold Damage to Spells
 Gain 5% of Non-Chaos Damage as extra Chaos Damage
 +27% to Global Critical Strike Multiplier (crafted)
 """,
+    # 2
     f"""Rarity: Rare
 Skull Pelt
 Destroyer Regalia
@@ -55,6 +57,7 @@ Item Level: 82
 --------
 Corrupted
 """,
+    # 3
     f"""Rarity: Rare
 Gloom Vise
 Assassin's Mitts
@@ -79,6 +82,7 @@ Item Level: 78
 +11 Life gained on Kill
 +19% to Fire and Cold Resistances (crafted)
 """,
+    # 4
     f"""Rarity: Unique
 Starkonja's Head
 Silken Hood
@@ -107,6 +111,7 @@ Item Level: 79
 There was no hero made out of Starkonja's death,
 but merely a long sleep made eternal.
 """,
+    # 5
     f"""Rarity: Rare
 Dread Hunger
 Karui Chopper
@@ -135,6 +140,7 @@ Adds 21 to 40 Cold Damage
 --------
 Redeemer Item
 """,
+    # 6
     f"""Rarity: Rare
 Rapture Caress
 Fingerless Silk Gloves
@@ -159,6 +165,7 @@ Adds 3 to 7 Physical Damage to Attacks
 --------
 Warlord Item
 """,
+    # 7
     f"""Rarity: Rare
 Grim Ward
 Oiled Vest
@@ -184,6 +191,7 @@ Item Level: 12
 19% increased Stun and Block Recovery
 +242 to Evasion Rating (crafted)
 """,
+    # 8
     f"""Rarity: Magic
 Rotund Sun Plate of the Lizard
 --------
@@ -200,6 +208,7 @@ Item Level: 61
 +64 to maximum Life
 Regenerate 2.5 Life per second
 """,
+    # 9
     f"""Rarity: Normal
 Steel Ring
 --------
@@ -210,6 +219,7 @@ Item Level: 78
 --------
 Adds 3 to 11 Physical Damage to Attacks (implicit)
 """,
+    # 10
     f"""Rarity: Gem
 Empower Support
 --------
@@ -229,6 +239,7 @@ This is a Support Gem. It does not grant a bonus to your character, but to skill
 --------
 Corrupted
 """,
+    # 11
     f"""Rarity: Normal
 The Jeweller's Touch
 --------
@@ -240,6 +251,7 @@ Right-click to add this prophecy to your character.
 --------
 Note: ~price 9 chaos
 """,
+    # 12
     f"""Rarity: Rare
 Cataclysm Brow
 Necromancer Circlet
@@ -265,6 +277,7 @@ Reflects 10 Physical Damage to Melee Attackers
 Nearby Enemies have -9% to Cold Resistance
 +47 to maximum Mana (crafted)
 """,
+    # 13
     f"""Rarity: Rare
 Entropy Blow
 Crimson Jewel
@@ -277,6 +290,7 @@ Item Level: 84
 --------
 Place into an allocated Jewel Socket on the Passive Skill Tree. Right click to remove from the Socket.
 """,
+    # 14
     f"""Rarity: Divination Card
 A Mother's Parting Gift
 --------
@@ -291,6 +305,7 @@ Knowledge was her gift.
 --------
 Shift click to unstack.
 """,
+    # 15
     f"""Rarity: Unique
 Hands of the High Templar
 Crusader Gloves
@@ -321,6 +336,7 @@ The laws of the faith do not apply to its leader.
 --------
 Corrupted
 """,
+    # 16
     f"""Rarity: Rare
 Dread Knot
 Synthesised Ruby Ring

--- a/utils/config.py
+++ b/utils/config.py
@@ -7,3 +7,4 @@ USE_HOTKEYS = True if config["GENERAL"]["useHotKeys"] == "yes" else False
 LEAGUE = config["GENERAL"]["league"]
 USE_GUI = True if config["GENERAL"]["useGUI"] == "yes" else False
 PROJECT_URL = config["GENERAL"]["projectURL"]
+MIN_RESULTS = 10

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,3 +14,5 @@ PROJECT_URL = config["GENERAL"]["projectURL"]
 VERSION = config["GENERAL"]["version"]
 
 RELEASE_URL = config["GENERAL"]["releaseURL"]
+
+MIN_RESULTS = 10

--- a/utils/gui.py
+++ b/utils/gui.py
@@ -160,7 +160,7 @@ class Gui:
         time.sleep(5)
         self.hide()
 
-    def show_price(self, price, price_vals, avg_times):
+    def show_price(self, price, price_vals, avg_times, not_enough=False):
         """
         Assemble the simple pricing window. Will overhaul this to get a better GUI in a future update.
         """
@@ -230,6 +230,23 @@ class Gui:
 
         maxPriceLabel = Label(self.root, text="High: " + str(price[2]), bg="#0d0d0d", fg="#e6b800")
         maxPriceLabel.grid(column=2, row=rows_used + 3, padx=10)
+
+        extrabgLabel = None
+        extrabgLabel2 = None
+        notEnoughLabel = None
+        manualSearchLabel = None
+
+        if not_enough:
+            extrabgLabel = Label(self.root, bg="#0d0d0d")
+            extrabgLabel.grid(column=0, row=rows_used + 4, columnspan=3, sticky="w" + "e")
+            notEnoughText = "Found limited search results"
+            notEnoughLabel = Label(self.root, text=notEnoughText, bg="#0d0d0d", fg="#e6b800")
+            notEnoughLabel.grid(column=0, row=rows_used + 4, columnspan=3)
+            extrabgLabel2 = Label(self.root, bg="#0d0d0d")
+            extrabgLabel2.grid(column=0, row=rows_used + 5, columnspan=3, sticky="w" + "e")
+            manualSearchText = "Use alt+t to search manually"
+            manualSearchLabel = Label(self.root, text=manualSearchText, bg="#0d0d0d", fg="#e6b800")
+            manualSearchLabel.grid(column=0, row=rows_used + 5, columnspan=3)
 
         # Show the new GUI, then get rid of it after 5 seconds. Might lower delay in the future.
         self.show()

--- a/utils/testGui.py
+++ b/utils/testGui.py
@@ -14,6 +14,36 @@ if os.name == "nt":
 def windowEnumerationHandler(hwnd, top_windows):
     top_windows.append((hwnd, win32gui.GetWindowText(hwnd)))
 
+def assemble_not_enough_data():
+    root = Toplevel()
+    root.overrideredirect(True)
+
+    # This is necessary for displaying the GUI window above active window(s) on the Windows OS
+    if os.name == "nt":
+        # In order to prevent SetForegroundWindow from erroring, we must satisfy the requirements
+        # listed here:
+        # https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow
+        # We satisfy this by internally sending the alt character so that Windows believes we are
+        # an active window.
+        shell = win32com.client.Dispatch("WScript.Shell")
+        shell.SendKeys("%")
+        win32gui.SetForegroundWindow(root.winfo_id())
+
+    x = root.winfo_pointerx()
+    y = root.winfo_pointery()
+
+    abs_coord_x = root.winfo_pointerx() - root.winfo_rootx()
+    abs_coord_y = root.winfo_pointery() - root.winfo_rooty()
+    root.geometry(f"364x40+{abs_coord_x}+{abs_coord_y}")
+
+    text = "Not enough results found to confidently price this item."
+    annotation = "You should manually search for it."
+    Label(root, text=text).grid(column=0, row=0)
+    Label(root, text=annotation).grid(column=0, row=1)
+
+    root.update()
+    time.sleep(5)
+    root.destroy()
 
 def assemble_price_gui(price, currency):
     root = Toplevel()


### PR DESCRIPTION
This PR was initially in regards to https://github.com/Ethck/Path-of-Accounting/issues/108

Now, when we display a pricing GUI to the user, if we found less than config.MIN_RESULTS (default: 10) results when searching for their item, we will tell them that we found limited results and suggest that they use `alt+t` to perform a manual search.

This PR also introduces mocked testing for our primary CI testing path which works without connectivity to pathofexile.com/trade, but includes the original live-internet test via `testing_legacy.py` to be ran at developer's convenience.

