### PR TITLE
Show GUI when base searching

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -1114,8 +1114,6 @@ def search_ninja_base(text):
         if config.USE_GUI:
             gui.show_base_result(base, influence, ilvl, price, currency)
 
-
-
 def hotkey_handler(keyboard, hotkey):
     # Without this block, the clipboard's contents seem to always be from 1 before the current
     if hotkey != "clipboard":

--- a/parse.py
+++ b/parse.py
@@ -1066,6 +1066,56 @@ def watch_keyboard(keyboard, use_hotkeys):
     keyboard.start()
 
 
+def search_ninja_base(text):
+    info = parse_item_info(text)
+    influence = None
+    if any(i == True for i in info["influenced"].values()):
+        if info["influenced"]["shaper"]:
+            influence = "shaper"
+        elif info["influenced"]["elder"]:
+            influence = "elder"
+        elif info["influenced"]["crusader"]:
+            influence = "crusader"
+        elif info["influenced"]["warlord"]:
+            influence = "warlord"
+        elif info["influenced"]["redeemer"]:
+            influence = "redeemer"
+        elif info["influenced"]["hunter"]:
+            influence = "hunter"
+
+    ilvl = info["ilvl"] if info["ilvl"] >= 84 else 84
+
+    base = info["itype"] if info["itype"] != None else info["base"]
+
+    print(f"[*] Searching for base {base}. Item Level: {ilvl}, Influence: {influence}")
+    result = None
+    try:
+        result = next(
+            item
+            for item in NINJA_BASES
+            if (
+                item["base"] == base
+                and (
+                    (influence == None and item["influence"] == None)
+                    or (influence != None and item["influence"] != None and influence == item["influence"].lower())
+                )
+                and ilvl == item["ilvl"]
+            )
+        )
+    except StopIteration:
+        print("[!] Could not find the requested item.")
+        if config.USE_GUI:
+            gui.show_not_enough_data()
+
+    if result != None:
+        price = result["exalt"] if result["exalt"] >= 1 else result["chaos"]
+        currency = "ex" if result["exalt"] >= 1 else "chaos"
+        print(f"[$] Price: {price} {currency}")
+        if config.USE_GUI:
+            gui.show_base_result(base, influence, ilvl, price, currency)
+
+
+
 def hotkey_handler(keyboard, hotkey):
     # Without this block, the clipboard's contents seem to always be from 1 before the current
     if hotkey != "clipboard":
@@ -1103,51 +1153,7 @@ def hotkey_handler(keyboard, hotkey):
         wiki_lookup(text, info)
 
     elif hotkey == "alt+c":
-        info = parse_item_info(text)
-        influence = None
-        if any(i == True for i in info["influenced"].values()):
-            if info["influenced"]["shaper"]:
-                influence = "shaper"
-            elif info["influenced"]["elder"]:
-                influence = "elder"
-            elif info["influenced"]["crusader"]:
-                influence = "crusader"
-            elif info["influenced"]["warlord"]:
-                influence = "warlord"
-            elif info["influenced"]["redeemer"]:
-                influence = "redeemer"
-            elif info["influenced"]["hunter"]:
-                influence = "hunter"
-
-        ilvl = info["ilvl"] if info["ilvl"] >= 84 else 84
-
-        base = info["itype"] if info["itype"] != None else info["base"]
-
-        print(f"[*] Searching for base {base}. Item Level: {ilvl}, Influence: {influence}")
-        result = None
-        try:
-            result = next(
-                item
-                for item in NINJA_BASES
-                if (
-                    item["base"] == base
-                    and (
-                        (influence == None and item["influence"] == None)
-                        or (influence != None and item["influence"] != None and influence == item["influence"].lower())
-                    )
-                    and ilvl == item["ilvl"]
-                )
-            )
-        except StopIteration:
-            print("[!] Could not find the requested item.")
-            gui.show_not_enough_data()
-
-        if result != None:
-            price = result["exalt"] if result["exalt"] >= 1 else result["chaos"]
-            currency = "ex" if result["exalt"] >= 1 else "chaos"
-            print(f"[$] Price: {price} {currency}")
-            if config.USE_GUI:
-                gui.show_base_result(base, influence, ilvl, price, currency)
+        search_ninja_base(text)
 
     else:  # alt+d, ctrl+c
         price_item(text)

--- a/parse.py
+++ b/parse.py
@@ -1140,11 +1140,14 @@ def hotkey_handler(keyboard, hotkey):
             )
         except StopIteration:
             print("[!] Could not find the requested item.")
+            gui.show_not_enough_data()
 
         if result != None:
             price = result["exalt"] if result["exalt"] >= 1 else result["chaos"]
             currency = "ex" if result["exalt"] >= 1 else "chaos"
             print(f"[$] Price: {price} {currency}")
+            if config.USE_GUI:
+                gui.show_base_result(base, influence, ilvl, price, currency)
 
     else:  # alt+d, ctrl+c
         price_item(text)

--- a/testing.py
+++ b/testing.py
@@ -167,6 +167,45 @@ class TestItemLookup(unittest.TestCase):
                     expectedStr = ("%s, " % Fore.WHITE).join(priceList)
                     self.assertTrue(expectedStr in out.getvalue())
 
+    def test_base_lookups(self):
+        config.USE_GUI = False
+
+        # Mock json data for poe.ninja bases
+        data = {
+            "lines": [
+                {
+                    "baseType": "Boot Blade",
+                    "levelRequired": 84,
+                    "variant": None,
+                    "corrupted": True,
+                    "exaltedValue": 0.5,
+                    "chaosValue": 80.0
+                }
+            ]
+        }
+
+        expected = [
+            lambda v: "[$]" in v,
+            lambda v: "[!]" in v
+        ]
+
+        for i in range(len(items[:2])):
+            item = items[i]
+
+            out = io.StringIO()
+            sys.stdout = out
+
+            # Needs mocking
+            with requests_mock.Mocker() as mock:
+                mock.get("https://poe.ninja/api/data/itemoverview?league=Metamorph&type=BaseType&language=en", json=data)
+                parse.NINJA_BASES = parse.get_ninja_bases()
+
+            parse.search_ninja_base(item)
+
+            sys.stdout = sys.__stdout__
+
+            self.assertTrue(expected[i](out.getvalue()))
+
 if __name__ == "__main__":
     init(autoreset=True) # Colorama
     unittest.main(failfast=True)

--- a/testing.py
+++ b/testing.py
@@ -180,6 +180,54 @@ class TestItemLookup(unittest.TestCase):
                     "corrupted": True,
                     "exaltedValue": 0.5,
                     "chaosValue": 80.0
+                },
+                {
+                    "baseType": "Boot Blade",
+                    "levelRequired": 84,
+                    "variant": "Elder",
+                    "corrupted": True,
+                    "exaltedValue": 0.5,
+                    "chaosValue": 80.0
+                },
+                {
+                    "baseType": "Boot Blade",
+                    "levelRequired": 84,
+                    "variant": "Shaper",
+                    "corrupted": True,
+                    "exaltedValue": 0.5,
+                    "chaosValue": 80.0
+                },
+                {
+                    "baseType": "Boot Blade",
+                    "levelRequired": 84,
+                    "variant": "Warlord",
+                    "corrupted": True,
+                    "exaltedValue": 0.5,
+                    "chaosValue": 80.0
+                },
+                {
+                    "baseType": "Boot Blade",
+                    "levelRequired": 84,
+                    "variant": "Redeemer",
+                    "corrupted": True,
+                    "exaltedValue": 0.5,
+                    "chaosValue": 80.0
+                },
+                {
+                    "baseType": "Boot Blade",
+                    "levelRequired": 84,
+                    "variant": "Crusader",
+                    "corrupted": True,
+                    "exaltedValue": 0.5,
+                    "chaosValue": 80.0
+                },
+                {
+                    "baseType": "Boot Blade",
+                    "levelRequired": 84,
+                    "variant": "Hunter",
+                    "corrupted": False,
+                    "exaltedValue": 0.5,
+                    "chaosValue": 80.0
                 }
             ]
         }
@@ -189,22 +237,47 @@ class TestItemLookup(unittest.TestCase):
             lambda v: "[!]" in v
         ]
 
+        # Needs mocking to prepare NINJA_BASES properly in parse.py
+        with requests_mock.Mocker() as mock:
+            mock.get("https://poe.ninja/api/data/itemoverview?league=Metamorph&type=BaseType&language=en", json=data)
+            parse.NINJA_BASES = parse.get_ninja_bases()
+
         for i in range(len(items[:2])):
             item = items[i]
 
             out = io.StringIO()
             sys.stdout = out
 
-            # Needs mocking
-            with requests_mock.Mocker() as mock:
-                mock.get("https://poe.ninja/api/data/itemoverview?league=Metamorph&type=BaseType&language=en", json=data)
-                parse.NINJA_BASES = parse.get_ninja_bases()
-
             parse.search_ninja_base(item)
 
             sys.stdout = sys.__stdout__
 
             self.assertTrue(expected[i](out.getvalue()))
+
+        # We'll take the first sample item and modify it so that we
+        # can match against all types of influences we support.
+        item = items[0]
+
+        supportedInfluence = [
+            "Elder",
+            "Shaper",
+            "Warlord",
+            "Redeemer",
+            "Crusader",
+            "Hunter"
+        ]
+
+        for inf in supportedInfluence:
+            current = item + ("%s Item\n" % inf)
+
+            out = io.StringIO()
+            sys.stdout = out
+
+            parse.search_ninja_base(current)
+
+            sys.stdout = sys.__stdout__
+
+            self.assertTrue(expected[0](out.getvalue()))
 
 if __name__ == "__main__":
     init(autoreset=True) # Colorama

--- a/utils/gui.py
+++ b/utils/gui.py
@@ -141,6 +141,53 @@ class Gui:
 
         self.last_task = self.root.after(delay, self.hide)
 
+    def show_base_result(self, base, influence, ilvl, price, currency):
+        """
+        Assemble a simple poe.ninja result when searching for the
+        worth of an item base, including it's influence and item level.
+        """
+        self.reset()
+
+        masterFrame = Frame(self.root, bg="#1f1f1f")
+        masterFrame.place(relwidth=1, relheight=1)
+
+        baseLabel = Label(self.root,
+            text="Base: %s" % base,
+            bg="#1f1f1f",
+            fg="#e6b800"
+        )
+        baseLabel.grid(column=0, row=0)
+
+        row = 1
+        if influence is not None:
+            row += 1
+            influenceLabel = Label(self.root,
+                text="Influence: %s" % influence,
+                bg="#1f1f1f",
+                fg="#e6b800"
+            )
+            influenceLabel.grid(column=0, row=row)
+
+        row += 1
+        itemLevelLabel = Label(self.root,
+            text="Item Level: %d" % ilvl,
+            bg="#1f1f1f",
+            fg="#e6b800"
+        )
+        itemLevelLabel.grid(column=0, row=row)
+
+        row += 1
+        priceLabel = Label(self.root,
+            text="Price: %d %s" % (price, currency),
+            bg="#1f1f1f",
+            fg="#e6b800"
+        )
+        priceLabel.grid(column=0, row=row)
+
+        self.show()
+        time.sleep(5)
+        self.hide()
+
     def show_not_enough_data(self):
         """
         Assemble a simple informative window which tells the user

--- a/utils/gui.py
+++ b/utils/gui.py
@@ -161,8 +161,18 @@ class Gui:
         row = 1
         if influence is not None:
             row += 1
+
+            conversion = {
+                "elder": "Elder",
+                "shaper": "Shaper",
+                "redeemer": "Redeemer",
+                "crusader": "Crusader",
+                "warlord": "Warlord",
+                "hunter": "Hunter"
+            }
+
             influenceLabel = Label(self.root,
-                text="Influence: %s" % influence,
+                text="Influence: %s" % conversion[influence],
                 bg="#1f1f1f",
                 fg="#e6b800"
             )


### PR DESCRIPTION
In regards to https://github.com/Ethck/Path-of-Accounting/issues/128

Shows a quite simple GUI with info about the item base being searched
accompanied by it's price found.

Furthermore, if we can't find the item base when searching for a base,
we'll now display the not enough data gui.

Signed-off-by: Kevin Morris <kevr.gtalk@gmail.com>